### PR TITLE
Corrected git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Video coming soon...
 ## Quickstart
 
 ```
-git clone https://github.com/PatrickAlphaC/hardhat-fund-me-fcc
-cd hardhat-fund-me-fcc
+git clone https://github.com/PatrickAlphaC/hardhat-smartcontract-lottery-fcc
+cd hardhat-smartcontract-lottery-fcc
 yarn
 ```
 


### PR DESCRIPTION
Before it is pointed towards https://github.com/PatrickAlphaC/hardhat-fund-me-fcc, Fund-me Dapp.
After correction it will point towards https://github.com/PatrickAlphaC/hardhat-smartcontract-lottery-fcc. Lottery Dapp