### PR TITLE
Update 01-deploy-raffle.js

### DIFF
--- a/deploy/01-deploy-raffle.js
+++ b/deploy/01-deploy-raffle.js
@@ -38,8 +38,8 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
         subscriptionId,
         networkConfig[chainId]["gasLane"],
         networkConfig[chainId]["keepersUpdateInterval"],
-        networkConfig[chainId]["raffleEntranceFee"],
         networkConfig[chainId]["callbackGasLimit"],
+        networkConfig[chainId]["raffleEntranceFee"],
     ]
     const raffle = await deploy("Raffle", {
         from: deployer,


### PR DESCRIPTION
swapped arguments "callbackGasLimit" & "raffleEntranceFee" of deploy-raffle. 

I had to do this to get my raffle contract to deploy without error - caused by the ordering.