### PR TITLE
Ordered Variables for better Gas Optimization 

### DIFF
--- a/contracts/Raffle.sol
+++ b/contracts/Raffle.sol
@@ -29,8 +29,8 @@ contract Raffle is VRFConsumerBaseV2, KeeperCompatibleInterface {
     uint64 private immutable i_subscriptionId;
     bytes32 private immutable i_gasLane;
     uint32 private immutable i_callbackGasLimit;
-    uint16 private constant REQUEST_CONFIRMATIONS = 3;
     uint32 private constant NUM_WORDS = 1;
+    uint16 private constant REQUEST_CONFIRMATIONS = 3;
 
     // Lottery Variables
     uint256 private immutable i_interval;


### PR DESCRIPTION
As we know EVM stores data in slots of 256 bits. A `uint256` integer takes up the whole slot but if we have a `unit` that is not of 256bits like unit128, then EVM does some optimization and stores two uint128 in one lot. WHich saves some memory and ofc it costs cheaper gas. But for that to work both the `uint128-uint128` should be written together.

So here we have two uint32s, but they are not written together. That means we aren't taking the advantage of the feature EVM provides. So I just did nothing, just change the formation and wrote both of them together so they can cost a bit cheaper gas.

For more info check this out: https://youtube.com/clip/UgkxLPLGks7TDDbxg3vB69k6oRl-_hFLWkxE

I hope that Patrick, FCC & the community will appreciate my small contribution :)
Thanks