### PR TITLE
Fix test failure by removing addConsumer code from config

### DIFF
--- a/deploy/01-deploy-raffle.js
+++ b/deploy/01-deploy-raffle.js
@@ -48,11 +48,6 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
         waitConfirmations: waitBlockConfirmations,
     })
 
-    // Programmatically adding a consumer for the vrfCoordinatorV2Mock
-    if (developmentChains.includes(network.name)) {
-        await vrfCoordinatorV2Mock.addConsumer(subscriptionId.toNumber(), raffle.address)
-    }
-
     // Verify the deployment
     if (!developmentChains.includes(network.name) && process.env.ETHERSCAN_API_KEY) {
         log("Verifying...")

--- a/test/unit/Raffle.test.js
+++ b/test/unit/Raffle.test.js
@@ -20,7 +20,7 @@ const { developmentChains, networkConfig } = require("../../helper-hardhat-confi
           })
 
           describe("constructor", function () {
-              it("intitiallizes the raffle correctly", async () => {
+              it("initializes the raffle correctly", async () => {
                   // Ideally, we'd separate these out so that only 1 assert per "it" block
                   // And ideally, we'd make this check everything
                   const raffleState = (await raffle.getRaffleState()).toString()


### PR DESCRIPTION
Remove addConsumer code snippet from raffle deploy script

When running the spec with `hh test` it failed with this output:

```
1) Raffle Unit Tests
    "before each" hook for "intitiallizes the raffle correctly":
  ERROR processing hardhat-smartcontract-lottery-fcc/deploy/01-deploy-raffle.js:
Error: VM Exception while processing transaction: reverted with reason string 'not implemented'
```

The solution proposed here helped:
https://github.com/smartcontractkit/full-blockchain-solidity-course-js/discussions/2076#discussioncomment-3483438
