### PR TITLE
Removed unused requires

### DIFF
--- a/test/staging/Raffle.staging.test.js
+++ b/test/staging/Raffle.staging.test.js
@@ -1,6 +1,6 @@
 const { assert, expect } = require("chai")
-const { getNamedAccounts, deployments, ethers, network } = require("hardhat")
-const { developmentChains, networkConfig } = require("../../helper-hardhat-config")
+const { getNamedAccounts, ethers, network } = require("hardhat")
+const { developmentChains } = require("../../helper-hardhat-config")
 
 developmentChains.includes(network.name)
     ? describe.skip


### PR DESCRIPTION
Removed unused requires from hardhat and helper-hardhat-config.