### PR TITLE
update deploy script to resolve #96

### DIFF
--- a/deploy/01-deploy-raffle.js
+++ b/deploy/01-deploy-raffle.js
@@ -48,6 +48,12 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
         waitConfirmations: waitBlockConfirmations,
     })
 
+    // !InvalidConsumer()error without adding raffle as the consumer of the Mock. (issue doesn't occur in vrfCoordinatorV2Mock ^0.8.0 as addConsumer is not implemented)
+
+    if (chainId == 31337) {
+        await vrfCoordinatorV2Mock.addConsumer(subscriptionId, raffle.address)
+    }
+
     // Verify the deployment
     if (!developmentChains.includes(network.name) && process.env.ETHERSCAN_API_KEY) {
         log("Verifying...")


### PR DESCRIPTION
The latest version (pragma solidity ^0.8.4) of Chainlink VRFCoordinatorV2 implemented the addConsumer function. InvalidConsumer()error will occur during the unit test without adding the raffle contract as a consumer of the Mock. 