### PR TITLE
Modify raffleEntranceFee to ETH 0.001 (goerli)

### DIFF
--- a/helper-hardhat-config.js
+++ b/helper-hardhat-config.js
@@ -10,7 +10,7 @@ const networkConfig = {
         subscriptionId: "588",
         gasLane: "0xd89b2bf150e3b9e13446986e571fb9cab24b13cea0a43ea20a6049a85cc807cc", // 30 gwei
         keepersUpdateInterval: "30",
-        raffleEntranceFee: ethers.utils.parseEther("0.01"), // 0.1 ETH
+        raffleEntranceFee: ethers.utils.parseEther("0.01"), // 0.01 ETH
         callbackGasLimit: "500000", // 500,000 gas
     },
     5: {
@@ -18,7 +18,7 @@ const networkConfig = {
         subscriptionId: "6926",
         gasLane: "0x79d3d8832d904592c0bf9818b621522c988bb8b0c05cdc3b15aea1b6e8db0c15", // 30 gwei
         keepersUpdateInterval: "30",
-        raffleEntranceFee: ethers.utils.parseEther("0.01"), // 0.1 ETH
+        raffleEntranceFee: ethers.utils.parseEther("0.001"), // 0.001 ETH
         callbackGasLimit: "500000", // 500,000 gas
         vrfCoordinatorV2: "0x2Ca8E0C643bDe4C2E08ab1fA0da3401AdAD7734D",
     },


### PR DESCRIPTION
Just a recommendation, it's getting hard to accumulate Goerli ETH and it's a pain to wait hours for the faucet when troubleshooting testing in testnet.