### PR TITLE
Changed the bash code in Quickstart section

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Video coming soon...
 ## Quickstart
 
 ```
-git clone --branch typescript https://github.com/PatrickAlphaC/hardhat-fund-me-fcc
-cd hardhat-fund-me-fcc
+git clone --branch typescript https://github.com/PatrickAlphaC/hardhat-smartcontract-lottery-fcc
+cd hardhat-smartcontract-lottery-fcc
 yarn
 yarn typechain
 ```


### PR DESCRIPTION
I have 
:frog: changed the git clone link from ```https://github.com/PatrickAlphaC/hardhat-fund-me-fcc```
 to
``` https://github.com/PatrickAlphaC/hardhat-smartcontract-lottery-fcc```.
:frog: changed the cd from *hardhat-fund-me* to *hardhat-smartcontract-lottery*
As it should be cloned from hardhat-smartcontract-lottery repo, and