### PR TITLE
Change to s_players array to make it scalable for more players 

### DIFF
--- a/test/unit/Raffle.test.js
+++ b/test/unit/Raffle.test.js
@@ -35,7 +35,8 @@ const { developmentChains, networkConfig } = require("../../helper-hardhat-confi
 
           describe("enterRaffle", function () {
               it("reverts when you don't pay enough", async () => {
-                  await expect(raffle.enterRaffle()).to.be.revertedWith( // is reverted when not paid enough or raffle is not open
+                  await expect(raffle.enterRaffle()).to.be.revertedWith(
+                      // is reverted when not paid enough or raffle is not open
                       "Raffle__SendMoreToEnterRaffle"
                   )
               })
@@ -45,7 +46,8 @@ const { developmentChains, networkConfig } = require("../../helper-hardhat-confi
                   assert.equal(player.address, contractPlayer)
               })
               it("emits event on enter", async () => {
-                  await expect(raffle.enterRaffle({ value: raffleEntranceFee })).to.emit( // emits RaffleEnter event if entered to index player(s) address
+                  await expect(raffle.enterRaffle({ value: raffleEntranceFee })).to.emit(
+                      // emits RaffleEnter event if entered to index player(s) address
                       raffle,
                       "RaffleEnter"
                   )
@@ -57,7 +59,8 @@ const { developmentChains, networkConfig } = require("../../helper-hardhat-confi
                   await network.provider.request({ method: "evm_mine", params: [] })
                   // we pretend to be a keeper for a second
                   await raffle.performUpkeep([]) // changes the state to calculating for our comparison below
-                  await expect(raffle.enterRaffle({ value: raffleEntranceFee })).to.be.revertedWith( // is reverted as raffle is calculating
+                  await expect(raffle.enterRaffle({ value: raffleEntranceFee })).to.be.revertedWith(
+                      // is reverted as raffle is calculating
                       "Raffle__RaffleNotOpen"
                   )
               })
@@ -99,11 +102,11 @@ const { developmentChains, networkConfig } = require("../../helper-hardhat-confi
                   await raffle.enterRaffle({ value: raffleEntranceFee })
                   await network.provider.send("evm_increaseTime", [interval.toNumber() + 1])
                   await network.provider.request({ method: "evm_mine", params: [] })
-                  const tx = await raffle.performUpkeep("0x") 
+                  const tx = await raffle.performUpkeep("0x")
                   assert(tx)
               })
               it("reverts if checkup is false", async () => {
-                  await expect(raffle.performUpkeep("0x")).to.be.revertedWith( 
+                  await expect(raffle.performUpkeep("0x")).to.be.revertedWith(
                       "Raffle__UpkeepNotNeeded"
                   )
               })
@@ -135,16 +138,17 @@ const { developmentChains, networkConfig } = require("../../helper-hardhat-confi
                   ).to.be.revertedWith("nonexistent request")
               })
 
-            // This test is too big...
-            // This test simulates users entering the raffle and wraps the entire functionality of the raffle
-            // inside a promise that will resolve if everything is successful.
-            // An event listener for the WinnerPicked is set up
-            // Mocks of chainlink keepers and vrf coordinator are used to kickoff this winnerPicked event
-            // All the assertions are done once the WinnerPicked event is fired
+              // This test is too big...
+              // This test simulates users entering the raffle and wraps the entire functionality of the raffle
+              // inside a promise that will resolve if everything is successful.
+              // An event listener for the WinnerPicked is set up
+              // Mocks of chainlink keepers and vrf coordinator are used to kickoff this winnerPicked event
+              // All the assertions are done once the WinnerPicked event is fired
               it("picks a winner, resets, and sends money", async () => {
                   const additionalEntrances = 3 // to test
                   const startingIndex = 2
-                  for (let i = startingIndex; i < startingIndex + additionalEntrances; i++) { // i = 2; i < 5; i=i+1
+                  for (let i = startingIndex; i < startingIndex + additionalEntrances; i++) {
+                      // i = 2; i < 5; i=i+1
                       raffle = raffleContract.connect(accounts[i]) // Returns a new instance of the Raffle contract connected to player
                       await raffle.enterRaffle({ value: raffleEntranceFee })
                   }
@@ -152,7 +156,8 @@ const { developmentChains, networkConfig } = require("../../helper-hardhat-confi
 
                   // This will be more important for our staging tests...
                   await new Promise(async (resolve, reject) => {
-                      raffle.once("WinnerPicked", async () => { // event listener for WinnerPicked
+                      raffle.once("WinnerPicked", async () => {
+                          // event listener for WinnerPicked
                           console.log("WinnerPicked event fired!")
                           // assert throws an error if it fails, so we need to wrap
                           // it in a try/catch so that the promise returns event
@@ -163,12 +168,12 @@ const { developmentChains, networkConfig } = require("../../helper-hardhat-confi
                               const raffleState = await raffle.getRaffleState()
                               const winnerBalance = await accounts[2].getBalance()
                               const endingTimeStamp = await raffle.getLastTimeStamp()
-                              await expect(raffle.getPlayer(0)).to.be.reverted
+                              await assert(raffle.getNumberOfPlayers().toString(), "0")
                               // Comparisons to check if our ending values are correct:
                               assert.equal(recentWinner.toString(), accounts[2].address)
                               assert.equal(raffleState, 0)
                               assert.equal(
-                                  winnerBalance.toString(), 
+                                  winnerBalance.toString(),
                                   startingBalance // startingBalance + ( (raffleEntranceFee * additionalEntrances) + raffleEntranceFee )
                                       .add(
                                           raffleEntranceFee
@@ -178,8 +183,8 @@ const { developmentChains, networkConfig } = require("../../helper-hardhat-confi
                                       .toString()
                               )
                               assert(endingTimeStamp > startingTimeStamp)
-                              resolve() // if try passes, resolves the promise 
-                          } catch (e) { 
+                              resolve() // if try passes, resolves the promise
+                          } catch (e) {
                               reject(e) // if try fails, rejects the promise
                           }
                       })


### PR DESCRIPTION
Changed `s_players` array to `mapping(uint256 => address) private s_playersMapping`
`uint256 private s_playersCount`, along with the implementation in the `fulfillRandomWords`. Now instead of working with arrays, contract uses mapping so chainlink VRF does not run out of gas in case there are a lot of players (running out of gas due to `new address[](0)` operation, now it is just changing the counter `s_playersCount = 0` for fixed gas).

Modified test case not to call the array values just to keep it complete. 