### PR TITLE
Test case: picks a winner, resets, and sends money

### DIFF
--- a/test/unit/Raffle.test.js
+++ b/test/unit/Raffle.test.js
@@ -194,8 +194,7 @@ const { developmentChains, networkConfig } = require("../../helper-hardhat-confi
                             raffle.address
                         )
                       } catch (e) {
-                          console.log(e);
-                          process.exit(1);
+                          reject(e)
                       }
                   })
               })

--- a/test/unit/Raffle.test.js
+++ b/test/unit/Raffle.test.js
@@ -185,13 +185,18 @@ const { developmentChains, networkConfig } = require("../../helper-hardhat-confi
                       })
 
                       // kicking off the event by mocking the chainlink keepers and vrf coordinator
-                      const tx = await raffle.performUpkeep("0x")
-                      const txReceipt = await tx.wait(1)
-                      const startingBalance = await accounts[2].getBalance()
-                      await vrfCoordinatorV2Mock.fulfillRandomWords(
-                          txReceipt.events[1].args.requestId,
-                          raffle.address
-                      )
+                      try {
+                        const tx = await raffle.performUpkeep("0x")
+                        const txReceipt = await tx.wait(1)
+                        const startingBalance = await accounts[2].getBalance()
+                        await vrfCoordinatorV2Mock.fulfillRandomWords(
+                            txReceipt.events[1].args.requestId,
+                            raffle.address
+                        )
+                      } catch (e) {
+                          console.log(e);
+                          process.exit(1);
+                      }
                   })
               })
           })


### PR DESCRIPTION
I had a challenge where the `vrfCoordinatorV2Mock.fulfillRandomWords()` function in the new Promise reverted but there was no error to indicate that on the console. The transaction simply timed out. I solved it by adding a try catch block to catch any transaction errors in the promise and log it to the console.

For more context, the cause of the bug was that I funded the subscription account with an integer `1` rather than a big number `ethers.utils.parseEther("1")`. This caused the transaction to revert with `InsufficientBalance()`. I couldn't see the error on the console and it took me some time to find out what was wrong.