### PR TITLE
Updated enterRaffle() logic

### DIFF
--- a/deploy/02-update-front-end.js
+++ b/deploy/02-update-front-end.js
@@ -21,7 +21,7 @@ async function updateContractAddresses() {
     const contractAddresses = JSON.parse(fs.readFileSync(frontEndContractsFile, "utf8"))
     if (network.config.chainId.toString() in contractAddresses) {
         if (!contractAddresses[network.config.chainId.toString()].includes(raffle.address)) {
-            contractAddresses[network.config.chainId.toString()].push(raffle.address)
+            contractAddresses[network.config.chainId.toString()]=raffle.address
         }
     } else {
         contractAddresses[network.config.chainId.toString()] = [raffle.address]


### PR DESCRIPTION
To avoid redundancy of the addresses in the array, s_players, if msg.sender calls the enterRaffle() multiple times:
 * we check if the address has already entered the raffle before calling enterRaffle() using mapping(address => uint256(i.e msg.value)):
         `if true ? increment s_addressToValue[msg.sender] with the msg.value: increment msg.value && s_players`
Hence, we only have unique addresses as indices in our s_players array
         