### PR TITLE
hot fix on 02-update-front-end.js

### DIFF
--- a/deploy/02-update-front-end.js
+++ b/deploy/02-update-front-end.js
@@ -11,6 +11,7 @@ module.exports = async () => {
     }
 }
 
+
 async function updateAbi() {
     const raffle = await ethers.getContract("Raffle")
     fs.writeFileSync(frontEndAbiFile, raffle.interface.format(ethers.utils.FormatTypes.json))
@@ -21,7 +22,7 @@ async function updateContractAddresses() {
     const contractAddresses = JSON.parse(fs.readFileSync(frontEndContractsFile, "utf8"))
     if (network.config.chainId.toString() in contractAddresses) {
         if (!contractAddresses[network.config.chainId.toString()].includes(raffle.address)) {
-            contractAddresses[network.config.chainId.toString()].push(raffle.address)
+            contractAddresses[network.config.chainId.toString()]=raffle.address
         }
     } else {
         contractAddresses[network.config.chainId.toString()] = [raffle.address]


### PR DESCRIPTION
multiple runs on 02-update-front-end.js creates multiple addresses, with the most recent address at the last index with this code snippet:
contractAddresses[network.config.chainId.toString()].push(raffle.address) 

This code snippet: const raffleAddress = chainId in contractAddresses ? contractAddresses[chainId][0] : null refers to the first index not the most recent address @PatrickAlphaC

instead, we can overwrite the contractAddress.json with the most recent address with this code snippet:

contractAddresses[network.config.chainId.toString()]=raffle.address  This overwrites the array with the most recently deployed address
Thanks @PatrickAlphaC @stevegee1